### PR TITLE
Update to Python 3.12

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/pytest-with-coverage.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -3,6 +3,9 @@ name: pytest-with-coverage
 on:
   push:
     branches: [ '*' ]
+  # Enable workflow to be triggered from GitHub CLI, browser, or via API
+  # primarily for testing conda env solution for new Python versions
+  workflow_dispatch:
 
 jobs:
   pytest-with-coverage:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -18,3 +18,5 @@ jobs:
       python-version: ${{ matrix.python-version }}
       conda-env-file: environment-test.yaml
       conda-env-name: nemo-nowcast-test
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/pytest-with-coverage.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Need to specify Python version here because we use test env which gets its
+        # Need to specify the Python version here because we use test env which gets its
         # Python version via matrix
-        python-version: [ '3.11' ]
+        python-version: [ '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/sphinx-linkcheck.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ NEMO Ocean Model Nowcast Framework
 .. image:: https://img.shields.io/badge/License-BSD%203--Clause-orange.svg
     :target: https://opensource.org/licenses/BSD-3-Clause
     :alt: Licensed under the BSD-3-Clause License
-.. image:: https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
-    :target: https://docs.python.org/3.11/
+.. image:: https://img.shields.io/badge/Python-3.12-blue?logo=python&label=Python&logoColor=gold
+    :target: https://docs.python.org/3.12/
     :alt: Python Versions
 .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
     :target: https://github.com/43ravens/NEMO_Nowcast

--- a/__pkg_metadata__.py
+++ b/__pkg_metadata__.py
@@ -16,5 +16,5 @@
 """
 PROJECT = "NEMO_Nowcast"
 DESCRIPTION = "NEMO ocean model nowcast framework"
-VERSION = "23.1.dev0"
+VERSION = "24.1.dev0"
 DEV_STATUS = "5 - Production/Stable"

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -2,7 +2,7 @@
 Change Log
 **********
 
-v23.1 (unreleased)
+v24.1 (unreleased)
 ==================
 
 *

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,7 +5,8 @@ Change Log
 v24.1 (unreleased)
 ==================
 
-*
+* Drop support for Python 3.10, and 3.11.
+  Minimum supported Python version is now 3.12.
 
 
 v22.1 (2023-01-23)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -25,8 +25,8 @@
 .. image:: https://img.shields.io/badge/license-BSD%203--Clause-orange.svg
     :target: https://opensource.org/licenses/BSD-3-Clause
     :alt: Licensed under the BSD-3-Clause License
-.. image:: https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
-    :target: https://docs.python.org/3.11/
+.. image:: https://img.shields.io/badge/Python-3.12-blue?logo=python&label=Python&logoColor=gold
+    :target: https://docs.python.org/3.12/
     :alt: Python Version
 .. image:: https://img.shields.io/badge/version%20control-git-blue.svg?logo=github
     :target: https://github.com/43ravens/NEMO_Nowcast
@@ -58,12 +58,12 @@
 Python Versions
 ===============
 
-.. image:: https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
-    :target: https://docs.python.org/3.11/
+.. image:: https://img.shields.io/badge/Python-3.12-blue?logo=python&label=Python&logoColor=gold
+    :target: https://docs.python.org/3.12/
     :alt: Python Version
 
 
-The :kbd:`SalishSeaNowcast` package is developed and tested using `Python`_ 3.11.
+The :kbd:`SalishSeaNowcast` package is developed and tested using `Python`_ 3.12.
 
 .. _Python: https://www.python.org/
 
@@ -332,7 +332,7 @@ The output looks something like:
     (         CHANGES: line   11) ok        https://github.com/SalishSeaCast/SalishSeaCmd/actions?query=workflow%3Acodeql-analysis
     (nowcast_system/elements: line   24) ok        https://github.com/SalishSeaCast/SalishSeaNowcast
     (     development: line  520) ok        https://github.com/mahmoud/boltons/blob/master/LICENSE
-    (     development: line   20) ok        https://img.shields.io/badge/Python-3.10%20%7C%203.11-blue?logo=python&label=Python&logoColor=gold
+    (     development: line   20) ok        https://img.shields.io/badge/Python-3.12-blue?logo=python&label=Python&logoColor=gold
     (     development: line   20) ok        https://img.shields.io/badge/code%20style-black-000000.svg
     (architecture/message_broker: line   48) ok        https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/devices/queue.html
     (     development: line   20) ok        https://img.shields.io/badge/license-BSD%203--Clause-orange.svg

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -64,9 +64,6 @@ Python Versions
 
 
 The :kbd:`SalishSeaNowcast` package is developed and tested using `Python`_ 3.11.
-The minimum supported Python version is 3.10.
-The :ref:`NEMO_NowcastContinuousIntegration` workflow on GitHub ensures that the package
-is tested for all versions of Python>=3.10.
 
 .. _Python: https://www.python.org/
 

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -17,7 +17,7 @@ dependencies:
   - arrow
   - attrs
   - pip
-  - python=3.11
+  - python=3.12
   - PyYAML
   - pyzmq
   - requests

--- a/environment-rtd.yaml
+++ b/environment-rtd.yaml
@@ -11,7 +11,7 @@ dependencies:
   - arrow
   - attrs
   - pip
-  - python=3.11
+  - python=3.12
   - pyyaml
   - pyzmq
   - schedule

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,4 +62,4 @@ tomli==2.0.1
 typing_extensions==4.4.0
 urllib3==1.26.19
 wheel==0.38.4
-zipp==3.13.0
+zipp==3.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
-cryptography==41.0.6
+cryptography==42.0.0
 docutils==0.17.1
 exceptiongroup==1.1.0
 idna==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,6 @@ supervisor==4.2.5
 toml==0.10.2
 tomli==2.0.1
 typing_extensions==4.4.0
-urllib3==1.26.18
+urllib3==1.26.19
 wheel==0.38.4
 zipp==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
-cryptography==42.0.0
+cryptography==42.0.2
 docutils==0.17.1
 exceptiongroup==1.1.0
 idna==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
-cryptography==42.0.4
+cryptography==43.0.1
 docutils==0.17.1
 exceptiongroup==1.1.0
 idna==3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ PyYAML==6.0
 pyzmq==25.0.0
 requests==2.32.0
 schedule==1.1.0
-sentry-sdk==1.15.0
+sentry-sdk==2.8.0
 setuptools==70.0.0
 six==1.16.0
 snowballstemmer==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ MarkupSafe==2.1.2
 mypy-extensions==1.0.0
 packaging==23.0
 pathspec==0.11.0
-pip==23.0
+pip==23.3
 platformdirs==3.0.0
 pluggy==1.0.0
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ attrs==22.2.0
 Babel==2.11.0
 black==24.3.0
 brotlipy==0.7.0
-certifi==2023.7.22
+certifi==2024.7.4
 cffi==1.15.1
 charset-normalizer==2.1.1
 click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,6 @@ supervisor==4.2.5
 toml==0.10.2
 tomli==2.0.1
 typing_extensions==4.4.0
-urllib3==1.26.17
+urllib3==1.26.18
 wheel==0.38.4
 zipp==3.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ alabaster==0.7.13
 arrow==1.2.3
 attrs==22.2.0
 Babel==2.11.0
-black==23.1.0
+black==24.3.0
 brotlipy==0.7.0
 certifi==2023.7.22
 cffi==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ idna==3.4
 imagesize==1.4.1
 importlib-metadata==6.0.0
 iniconfig==2.0.0
-Jinja2==3.1.2
+Jinja2==3.1.3
 MarkupSafe==2.1.2
 mypy-extensions==1.0.0
 packaging==23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ coverage==7.1.0
 cryptography==42.0.4
 docutils==0.17.1
 exceptiongroup==1.1.0
-idna==3.4
+idna==3.7
 imagesize==1.4.1
 importlib-metadata==6.0.0
 iniconfig==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
-cryptography==41.0.4
+cryptography==41.0.6
 docutils==0.17.1
 exceptiongroup==1.1.0
 idna==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ python-dateutil==2.8.2
 pytz==2022.7.1
 PyYAML==6.0
 pyzmq==25.0.0
-requests==2.31.0
+requests==2.32.0
 schedule==1.1.0
 sentry-sdk==1.15.0
 setuptools==67.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.6
 coverage==7.1.0
-cryptography==42.0.2
+cryptography==42.0.4
 docutils==0.17.1
 exceptiongroup==1.1.0
 idna==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ idna==3.7
 imagesize==1.4.1
 importlib-metadata==6.0.0
 iniconfig==2.0.0
-Jinja2==3.1.3
+Jinja2==3.1.4
 MarkupSafe==2.1.2
 mypy-extensions==1.0.0
 packaging==23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pyzmq==25.0.0
 requests==2.32.0
 schedule==1.1.0
 sentry-sdk==1.15.0
-setuptools==67.3.2
+setuptools==70.0.0
 six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==5.3.0

--- a/setup.py
+++ b/setup.py
@@ -18,21 +18,6 @@ from setuptools import find_packages, setup
 
 import __pkg_metadata__
 
-classifiers = [
-    "Development Status :: " + __pkg_metadata__.DEV_STATUS,
-    "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: POSIX :: Linux",
-    "Operating System :: Unix",
-    "Environment :: Console",
-    "Intended Audience :: Science/Research",
-    "Intended Audience :: Education",
-    "Intended Audience :: Developers",
-]
 try:
     long_description = open("README.rst", "rt").read()
 except IOError:
@@ -61,7 +46,6 @@ setup(
     author_email="doug.latornell@43ravens.ca",
     url="https://nemo-nowcast.readthedocs.io/en/latest/NEMO_Nowcast/",
     license="Apache License, Version 2.0",
-    classifiers=classifiers,
     platforms=["Linux"],
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
- [x] Add Python 3.12 to GHA pytest-with-coverage workflow so that we can use the workflow to test whether all the packages NEMONowcast depends on have been updated to support Python 3.12.
- [x] Add `workflow_dispatch` trigger to GHA pytest-with-coverage workflow to enable workflow to be triggered from
GitHub CLI, browser or via API
- [x] Drop Python 3.10 & 3.11 from GHA pytest-with-coverage workflow
- [x] Change conda environment descriptions to use Python 3.12
  - [x] `environment-dev.yaml`
  - [x] `environment-rtd.yaml`
- [x] Change sphinx-linkcheck workflow to Python 3.12
- [x] Change to Python 3.12 for package development